### PR TITLE
Update mets_xml_dmd_rdf.jinja2

### DIFF
--- a/ted_sws/notice_packager/resources/templates/mets_xml_dmd_rdf.jinja2
+++ b/ted_sws/notice_packager/resources/templates/mets_xml_dmd_rdf.jinja2
@@ -21,7 +21,7 @@
         <cdm:procurement_public_number_document_in_official-journal rdf:datatype="http://www.w3.org/2001/XMLSchema#string">{{ notice.public_number_document }}</cdm:procurement_public_number_document_in_official-journal>
         <cdm:procurement_public_number_edition rdf:datatype="http://www.w3.org/2001/XMLSchema#positiveInteger">{{ notice.public_number_edition }}</cdm:procurement_public_number_edition>
         {% for lang in work.title %}
-        <cdm:work_title xml:lang="{{ lang }}">{{ work.title[lang] }}</cdm:work_title>
+        <cdm:work_title xml:lang="{{ lang }}">{{ work.title[lang] | e }}</cdm:work_title>
         {% endfor %}
         <cdm:datetime_transmission rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ work.datetime_transmission }}</cdm:datetime_transmission>
         {# <cdm:procurement_public_issued_by_country>{{ work.procurement_public_issued_by_country }}</cdm:procurement_public_issued_by_country>
@@ -44,7 +44,7 @@
         <rdf:type rdf:resource="http://publications.europa.eu/ontology/cdm#expression_procurement_public"/>
         <cdm:expression_belongs_to_work rdf:resource="&resource;ted/{{ work.identifier }}"/>
         {% for lang in expression.title %}
-        <cdm:expression_title xml:lang="{{ lang }}">{{ expression.title[lang] }}</cdm:expression_title>
+        <cdm:expression_title xml:lang="{{ lang }}">{{ expression.title[lang] | e }}</cdm:expression_title>
         {% endfor %}
         <cdm:expression_uses_language rdf:resource="&cellar-authority;language/{{ expression.uses_language }}"/>
         <cdm:expression_procurement_public_authority-type_name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Other</cdm:expression_procurement_public_authority-type_name>


### PR DESCRIPTION
Fixes: https://github.com/OP-TED/ted-rdf-conversion-pipeline/issues/549

I could not clone the repository.

I Tested externally with jinja2 like this:

```
from jinja2 import Environment, FileSystemLoader, select_autoescape
import os

template_dir = os.path.dirname(os.path.abspath(__file__))
template_file = 'template.xml'

sample_data = {
    'work': {
        'identifier': '123456',
        'oj_identifier': 'OJ/2024/001',
        'do_not_index': 'true',
        'date_document': '2024-10-24',
        'created_by_agent': 'EU-CORP',
        'title': {
            'en': 'Public Procurement',
            'fr': 'Marché Public',
            'es': '<html>Some HTML and a & </html>'

        },
        'dataset_keyword': ['keyword1', 'keyword2', 'keyword3'],
        'datetime_transmission': '2024-10-24T14:30:00',
    },
    'notice': {
        'public_number_document': 'TED123',
        'public_number_edition': '1'
    },
    'expression': {
        'identifier': 'EXP123',
        'title': {
            'en': 'Procurement Document',
            'fr': 'Document de Marché',
            'es': '<html>Some HTML and a & </html>'

        },
        'uses_language': 'EN',
    },
    'manifestation': {
        'identifier': 'MAN123',
        'type': 'PDF',
        'date_publication': '2024-10-24',
        'distribution_has_status_distribution_status': 'PUBLISHED',
        'distribution_has_media_type_concept_media_type': 'FILE_TYPE_PDF',
    }
}

env = Environment(loader=FileSystemLoader(template_dir))
template = env.get_template(template_file)

output = template.render(sample_data)

output_file = os.path.join(template_dir, 'output.xml')
with open(output_file, 'w', encoding='utf-8') as f:
    f.write(output)

print(f"Rendered output saved to {output_file}")
```